### PR TITLE
Rearrange and improve ROS2 deploy script

### DIFF
--- a/setup/ansible_playbook.yml
+++ b/setup/ansible_playbook.yml
@@ -34,6 +34,8 @@
       - lsb-release
       - ros-humble-ros-desktop # TODO: Not everything by default
         # We should look at what is actually needed on ALL hosts, and only grab that
+      state: present
+      cache_valid_time: 86400
 
   - name: Remove unattended-upgrades
     ansible.builtin.apt:
@@ -48,4 +50,9 @@
       - ansible
       - adafruit-circuitpython-servokit
       - adafruit-circuitpython-motorkit
-     
+    
+  - name: Upgrade & Clean
+    ansible.builtin.apt:
+      upgradE: yes
+      clean: yes 
+      autoremove: yes

--- a/setup/ansible_playbook.yml
+++ b/setup/ansible_playbook.yml
@@ -53,6 +53,6 @@
     
   - name: Upgrade & Clean
     ansible.builtin.apt:
-      upgradE: yes
+      upgrade: yes
       clean: yes 
       autoremove: yes

--- a/setup/ansible_playbook.yml
+++ b/setup/ansible_playbook.yml
@@ -3,55 +3,41 @@
 #
 ---
 
-- name: install dependancies
+- name: Host install & configure
   become: yes
   become_user: root
   hosts: all
   tasks:
 
-  - name: update the apt cache
-    ansible.builtin.apt:
-      update_cache: yes
-      allow_unauthenticated: yes
+  - name: Install ROS2 GPG keys
+    ansible.builtin.apt_key: # TODO: retire depracated tool apt-key
+      url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+ 
+  - name: Add ROS2 Humble apt repo
+    ansible.builtin.apt_repository:
+      repo: deb http://packages.ros.org/ros2/ubuntu jammy main
 
-  - name: install all available apt upgrades
-    ansible.builtin.apt:
-      upgrade: yes
-      allow_unauthenticated: yes
-
-  - name: apt install depends
+  - name: Install components from apt
     ansible.builtin.apt:
       name:
       - python3-pip
       - curl
       - gnupg
       - lsb-release
+      - ros-humble-ros-desktop # TODO: Not everything by default
+        # We should look at what is actually needed on ALL hosts, and only grab that
 
-  - name: apt remove packages
+  - name: Remove unattended-upgrades
     ansible.builtin.apt:
       state: absent
       name:
       - unattended-upgrades
 
-  - name: pip install depends
+  - name: Install components from pip
     ansible.builtin.pip:
       state: latest
       name:
       - ansible
       - adafruit-circuitpython-servokit
       - adafruit-circuitpython-motorkit
-
-
-  - name: add ros2 humble apt repo key
-    ansible.builtin.apt_key:
-      url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
-      
-  - name: add ros2 humble apt repo
-    ansible.builtin.apt_repository:
-      repo: deb http://packages.ros.org/ros2/ubuntu jammy main
-
-  - name: apt install ros2 humble (THIS MAY TAKE A WHILE)
-    ansible.builtin.apt:
-      update_cache: yes
-      name:
-      - ros-humble-desktop
+     

--- a/setup/ansible_playbook.yml
+++ b/setup/ansible_playbook.yml
@@ -9,6 +9,14 @@
   hosts: all
   tasks:
 
+  - name: Ensure systemd and udev upgrades happen first
+    ansible.builtin.apt:
+      name:
+        - systemd
+      state: latest
+      cache_valid_time: 86400 # consider cache up-to-date if its < 1 day old
+      # this also sets update_cache: true implicitly, so that can be left out
+
   - name: Install ROS2 GPG keys
     ansible.builtin.apt_key: # TODO: retire depracated tool apt-key
       url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key


### PR DESCRIPTION
I've rearranged some components so we aren't repeating steps that are the same, or very nearly the same. Also added some cache lifetime hints so we (hopefully) make less noise reaching out to the package servers. Finally: A systemd upgrade task to make sure the script still behaves itself when run against old Ubuntu installs (according to the note in the ROS2 guide  [here](https://docs.ros.org/en/ros2_documentation/humble/Installation/Ubuntu-Install-Debians.html#install-ros-2-packages))