### PR TITLE
Upgrade those package definitions!

### DIFF
--- a/setup/roles/common/tasks/main.yaml
+++ b/setup/roles/common/tasks/main.yaml
@@ -32,6 +32,10 @@
     name:
       - python3
       - python3-pip
+    cache_valid_time: 86400
+    upgrade: "yes"
+    autoremove: true
+    clean: true
 
 - name: No unattended upgrades!
   ansible.builtin.apt:


### PR DESCRIPTION
Update and upgrade and (auto)clean the packages. Old package definitions will cause apt to try to pull down packages that don't exist on the remote repos anymore, and the ansible playbook emits a many, many, many thousands of characters long string of errors. Common performs a full upgrade and clean to address this. :v

Gotta use that brain o mine eventually.