### PR TITLE
add frame id's to i2c_proxy publishers

### DIFF
--- a/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
+++ b/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
@@ -117,7 +117,12 @@ def main(args=None):
 #        message_logic_tube_imu = Imu()
 
         # insert fame id
-        message_logic_tube_bme280_temperature.header.frame-id = "logic_tube"
+        message_logic_tube_bme280_temperature.header.frame-id = "base_link"
+        message_logic_tube_bme280_humidity.header.frame-id = "base_link"
+        message_logic_tube_bme280_pressure.header.frame-id = "base_link"
+        message_thrust_box_bme280_temperature.header.frame-id = "base_link"
+        message_thrust_box_bme280_humidity.header.frame-id = "base_link"
+        message_thrust_box_bme280_pressure.header.frame-id = "base_link"
 
         # grab the data from the sensors
         message_logic_tube_bme280_temperature.temperature = logic_tube_bme280.temperature

--- a/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
+++ b/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
@@ -116,6 +116,9 @@ def main(args=None):
         message_thrust_box_bme280_pressure = FluidPressure()
 #        message_logic_tube_imu = Imu()
 
+        # insert fame id
+        message_logic_tube_bme280_temperature.header.frame-id = "logic_tube"
+
         # grab the data from the sensors
         message_logic_tube_bme280_temperature.temperature = logic_tube_bme280.temperature
         message_logic_tube_bme280_humidity.relative_humidity = logic_tube_bme280.humidity


### PR DESCRIPTION
this fixes #29 

adds frame id data to the publishers in i2c_proxy so that rviz will work

@mike-matera can you look at this? my vs code says `Expression cannot be assignment target` on the lines added here