### PR TITLE
fix error with function not exist

### DIFF
--- a/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
+++ b/src/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py
@@ -113,7 +113,7 @@ for channel in thruster_channels:
     thrust_box_pwm.servo[channel].angle = 1500 # zero throttle at bootup
 
 servo_cam_channel = 15
-logic_tube_pwm.servo[servo_cam_channel].set_width_range(0, 3000)
+logic_tube_pwm.servo[servo_cam_channel].set_pulse_width_range(0, 3000)
 logic_tube_pwm.servo[servo_cam_channel].actuation_range = 3000
 logic_tube_pwm.servo[servo_cam_channel].angle = 1500
 


### PR DESCRIPTION
fixes error
```
[i2c_proxy-2]   File "/home/ubuntu/cabrillo_rov_2023/build/seahawk_rov/seahawk_rov/i2c_proxy/i2c_proxy.py", line 116, in <module>
[i2c_proxy-2]     logic_tube_pwm.servo[servo_cam_channel].set_width_range(0, 3000)
[i2c_proxy-2] AttributeError: 'Servo' object has no attribute 'set_width_range'. Did you mean: 'set_pulse_width_range'?
```