### PR TITLE
Treat phony make targets as phony targets

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,5 @@
 
+.PHONY: all clean
 all:
 	colcon build --symlink
 


### PR DESCRIPTION
The job of Make is to create files. It's smart about checking that those files are "up to date" but will otherwise skip the target. Creating a file named "all" or "clean" will cause make to do nothing when issuing the build and clean commands.

Marking the targets as phony causes make to treat them as always out of date, and so always runs the targets.