### PR TITLE
[seahawk_rov] Fix BNO085 IMU message data type

### DIFF
--- a/launch/rov.launch.py
+++ b/launch/rov.launch.py
@@ -24,5 +24,30 @@ def generate_launch_description():
             executable='seahawk_rov',
             name='seahawk_rov',
             output='screen'
+        ),
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='imu_transform',
+            output='screen',
+            arguments=[
+                # Offset from parent frame in meters
+                "--x",      "0",
+                "--y",      "0",
+                "--z",      "0",
+                # # Quaternion rotation. Alternately use --{roll,pitch,yaw} but those probably aren't ideal in the end
+                # "--qx",     "0",
+                # "--qy",     "0",
+                # "--qz",     "0",
+                # "--qw",     "0",
+                # RPY rotation in radians. This is not ideal, it would be better to use Quaternion rotation
+                "--roll",   "0",
+                "--pitch",  "0",
+                "--yaw",    "0",
+                # Parent frame to which the offset is provided
+                "--frame-id", "base_link",
+                # Created frame which is offset from parent frame
+                "--child-frame-id", "logic_tube_bno085",
+            ]
         )
     ])

--- a/launch/rov.launch.py
+++ b/launch/rov.launch.py
@@ -1,7 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
-from math import pi
+# from math import pi
 
 def generate_launch_description():
     return LaunchDescription([
@@ -41,10 +41,10 @@ def generate_launch_description():
                 # "--qy",     "0",
                 # "--qz",     "0",
                 # "--qw",     "0",
-                # RPY rotation in radians. This is not ideal, it would be better to use Quaternion rotation
-                "--roll",   f"{pi}",
-                "--pitch",  f"0",
-                "--yaw",    f"{-pi*0.5}",
+                # # RPY rotation in radians. This is not ideal, it would be better to use Quaternion rotation
+                # "--roll",   f"{pi}",
+                # "--pitch",  f"0",
+                # "--yaw",    f"{-pi*0.5}",
                 # Parent frame to which the offset is provided
                 "--frame-id", "base_link",
                 # Created frame which is offset from parent frame

--- a/launch/rov.launch.py
+++ b/launch/rov.launch.py
@@ -1,6 +1,7 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+from math import pi
 
 def generate_launch_description():
     return LaunchDescription([
@@ -32,18 +33,18 @@ def generate_launch_description():
             output='screen',
             arguments=[
                 # Offset from parent frame in meters
-                "--x",      "0",
-                "--y",      "0",
-                "--z",      "0",
+                "--x",      "0.17",
+                "--y",      "0.05",
+                "--z",      "0.07",
                 # # Quaternion rotation. Alternately use --{roll,pitch,yaw} but those probably aren't ideal in the end
                 # "--qx",     "0",
                 # "--qy",     "0",
                 # "--qz",     "0",
                 # "--qw",     "0",
                 # RPY rotation in radians. This is not ideal, it would be better to use Quaternion rotation
-                "--roll",   "0",
-                "--pitch",  "0",
-                "--yaw",    "0",
+                "--roll",   f"{pi}",
+                "--pitch",  f"0",
+                "--yaw",    f"{-pi*0.5}",
                 # Parent frame to which the offset is provided
                 "--frame-id", "base_link",
                 # Created frame which is offset from parent frame

--- a/src/seahawk_rov/seahawk_rov/__main__.py
+++ b/src/seahawk_rov/seahawk_rov/__main__.py
@@ -64,12 +64,12 @@ def main(args=None):
 
     # instanciate the sensor classes
     logic_tube_bme280 = seahawk_rov.LogicTubeBME280(node_seahawk_rov, i2c)
-    # logic_tube_bno085 = LogicTubeBNO085(node_seahawk_rov, i2c)
+    logic_tube_bno085 = seahawk_rov.LogicTubeBNO085(node_seahawk_rov, i2c)
     thrust_box_bme280 = seahawk_rov.ThrustBoxBME280(node_seahawk_rov, i2c)
     
     def publisher():
         logic_tube_bme280.publish()
-        # logic_tube_bno085.publish()
+        logic_tube_bno085.publish()
         thrust_box_bme280.publish()
 
     publish_timer = node_seahawk_rov.create_timer(0.1, publisher)

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -57,8 +57,6 @@ class LogicTubeBNO085:
         msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration
         msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
         msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w = self.bno.geomagnetic_quaternion
-        self.get_logger().info(f"Orientation  : {self.bno.geomagnetic_quaternion}")
-        self.get_logger().info(f"Acceleration : {self.bno.linear_acceleration}")
-        self.get_logger().info(f"Rotation     : {self.bno.gyro}")
+        
         # publish
         self.publisher.publish(msg)

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -55,11 +55,18 @@ class LogicTubeBNO085:
         msg.header.frame_id = "logic_tube_bno085"
 
         # load the message with data from the sensor
-        # IMU X right, Y up, Z back
-        # ROV Y right, Z down, X forward
-        msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w = self.bno.geomagnetic_quaternion
-        msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
-        msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration
+        # IMU X right, Y forward, Z up
+        # ROV Y right, X forward, Z down
+        msg.orientation.x = self.bno.geomagnetic_quaternion[1]
+        msg.orientation.y = self.bno.geomagnetic_quaternion[0]
+        msg.orientation.z = -self.bno.geomagnetic_quaternion[2]
+        msg.orientation.w = self.bno.geomagnetic_quaternion[3]
+        msg.angular_velocity.x = self.bno.gyro[1]
+        msg.angular_velocity.y = self.bno.gyro[0]
+        msg.angular_velocity.z = -self.bno.gyro[2]
+        msg.linear_acceleration.x = self.bno.linear_acceleration[1]
+        msg.linear_acceleration.y = self.bno.linear_acceleration[0]
+        msg.linear_acceleration.z = -self.bno.linear_acceleration[2]
 
         # publish
         self.publisher.publish(msg)

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -42,9 +42,9 @@ class LogicTubeBNO085:
         self.bno = BNO08X_I2C(i2c)
 
         # enable raw data outputs
-        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_RAW_ACCELEROMETER)
-        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_RAW_GYROSCOPE)
-        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_RAW_MAGNETOMETER)
+        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_LINEAR_ACCELERATION)
+        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GYROSCOPE)
+        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GEOMAGNETIC_ROTATION_VECTOR)
 
     def publish(self):
         # instantiate an imu message
@@ -54,9 +54,11 @@ class LogicTubeBNO085:
         msg.header.frame_id = "base_link"
 
         # load the message with data from the sensor
-        msg.linear_acceleration = self.bno.raw_acceleration
-        msg.angular_velocity = self.bno.raw_gyro
-        msg.orientation = self.bno.raw_quaternion
-
+        # msg.linear_acceleration = self.bno.linear_acceleration
+        # msg.angular_velocity = self.bno.gyro
+        # msg.orientation = self.bno.geomagnetic_quaternion
+        self.get_logger().info(f"Orientation  : {self.bno.geomagnetic_quaternion}")
+        self.get_logger().info(f"Acceleration : {self.bno.linear_acceleration}")
+        self.get_logger().info(f"Rotation     : {self.bno.gyro}")
         # publish
         self.publisher.publish(msg)

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -29,22 +29,23 @@ import time
 # ros message
 from sensor_msgs.msg import Imu
 
-# inport the bno085 circuit python sensor library
+# import the bno085 circuit python sensor library
 import adafruit_bno08x
 from adafruit_bno08x.i2c import BNO08X_I2C
+
 
 class LogicTubeBNO085:
     def __init__(self, node, i2c):
         # instantiate the publisher
         self.publisher = node.create_publisher(Imu, 'logic_tube/imu', 8)
 
-        # instanciate the sensor
+        # instantiate the sensor
         self.bno = BNO08X_I2C(i2c)
 
         # enable raw data outputs
-        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_LINEAR_ACCELERATION)
-        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GYROSCOPE)
         self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GEOMAGNETIC_ROTATION_VECTOR)
+        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GYROSCOPE)
+        self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_LINEAR_ACCELERATION)
 
     def publish(self):
         # instantiate an imu message
@@ -54,9 +55,9 @@ class LogicTubeBNO085:
         msg.header.frame_id = "base_link"
 
         # load the message with data from the sensor
-        msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration
-        msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
         msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w = self.bno.geomagnetic_quaternion
-        
+        msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
+        msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration
+
         # publish
         self.publisher.publish(msg)

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -52,9 +52,11 @@ class LogicTubeBNO085:
         msg = Imu()
 
         # add the frame id
-        msg.header.frame_id = "base_link"
+        msg.header.frame_id = "logic_tube_bno085"
 
         # load the message with data from the sensor
+        # IMU X right, Y up, Z back
+        # ROV Y right, Z down, X forward
         msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w = self.bno.geomagnetic_quaternion
         msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
         msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration

--- a/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
+++ b/src/seahawk_rov/seahawk_rov/logic_tube_bno085.py
@@ -54,9 +54,9 @@ class LogicTubeBNO085:
         msg.header.frame_id = "base_link"
 
         # load the message with data from the sensor
-        # msg.linear_acceleration = self.bno.linear_acceleration
-        # msg.angular_velocity = self.bno.gyro
-        # msg.orientation = self.bno.geomagnetic_quaternion
+        msg.linear_acceleration.x, msg.linear_acceleration.y, msg.linear_acceleration.z = self.bno.linear_acceleration
+        msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self.bno.gyro
+        msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w = self.bno.geomagnetic_quaternion
         self.get_logger().info(f"Orientation  : {self.bno.geomagnetic_quaternion}")
         self.get_logger().info(f"Acceleration : {self.bno.linear_acceleration}")
         self.get_logger().info(f"Rotation     : {self.bno.gyro}")


### PR DESCRIPTION
The Adafruit BNO085 report datatypes being different from the ROS Imu message type has been an outstanding issue for some time now. Fortunately, with this destructuring, it is no longer an issue, and the IMU is now publishing messages that seem to be correct. Of course, the IMU working is different from assigning the correct variables to the correct places. We probably have to test this on the actual robot before we merge this, to publish in the correct order.


closes #22 