### PR TITLE
Add graphical joystick debugger.

### DIFF
--- a/doc/controller_debug.ipynb
+++ b/doc/controller_debug.ipynb
@@ -18,7 +18,11 @@
    "outputs": [],
    "source": [
     "import evdev, time\n",
-    "joy = evdev.InputDevice('/dev/input/event14')\n",
+    "import pathlib \n",
+    "\n",
+    "for device in pathlib.Path('/dev/input/by-id/').glob('*Xbox*event-joystick'):\n",
+    "    print(\"Found joystick device:\", device)\n",
+    "joy = evdev.InputDevice(device)\n",
     "print(joy)"
    ]
   },
@@ -45,6 +49,49 @@
     "while True:\n",
     "    file.write(f\"{time.time()-now},{joy.absinfo(evdev.ecodes.ABS_X).value},{joy.absinfo(evdev.ecodes.ABS_Y).value},{joy.absinfo(evdev.ecodes.ABS_RX).value},{joy.absinfo(evdev.ecodes.ABS_RY).value}\\n\")\n",
     "    time.sleep(0.005)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipycanvas import Canvas, hold_canvas\n",
+    "from collections import namedtuple \n",
+    "\n",
+    "Point = namedtuple(\"Point\", \"x y\")\n",
+    "\n",
+    "stick_x = evdev.ecodes.ABS_X\n",
+    "stick_y = evdev.ecodes.ABS_Y \n",
+    "\n",
+    "canvas_size = Point(500, 500)\n",
+    "canvas_gutter = Point(50, 50)\n",
+    "canvas_origin = Point(canvas_size.x//2 + canvas_gutter.x, canvas_size.y//2 + canvas_gutter.x)\n",
+    "joy_size = Point( joy.absinfo(stick_x).max - joy.absinfo(stick_x).min, \n",
+    "                 joy.absinfo(stick_y).max - joy.absinfo(stick_y).min,\n",
+    "                 )\n",
+    "joy_origin = Point(0, 0)\n",
+    "\n",
+    "canvas = Canvas(width=canvas_size.x+2*canvas_gutter.x, height=canvas_size.y+2*canvas_gutter.x)\n",
+    "display(canvas)\n",
+    "\n",
+    "history_size = 100 \n",
+    "history = [Point(0,0)] * history_size\n",
+    "index = 0\n",
+    "while True:\n",
+    "    val = Point(\n",
+    "        (joy.absinfo(stick_x).value - joy_origin.x) * (canvas_size.x / joy_size.x) + canvas_origin.x,\n",
+    "        (joy.absinfo(stick_y).value - joy_origin.y) * (canvas_size.y / joy_size.y) + canvas_origin.y,\n",
+    "    )\n",
+    "    history[index] = val \n",
+    "    index = (index + 1) % history_size \n",
+    "    with hold_canvas():\n",
+    "        canvas.clear()\n",
+    "        for i, h in enumerate(history[index:] + history[0:index]):\n",
+    "            canvas.global_alpha = (i / history_size)\n",
+    "            canvas.fill_circle(h.x, h.y, 10)\n",
+    "        time.sleep(0.02)"
    ]
   }
  ],


### PR DESCRIPTION
@OrionOth -- I loved your Jupyter notebook for debugging the joystick. I contributed some code that lets you view the joystick position on an interactive canvas in Jupyter. You need to have the `ipycanvas` library and extension installed. I also change how you get the joystick device to something that should reliably grab the right one. 

Here's a screenshot of what I see when I run it: 

![Screenshot from 2023-04-19 18-05-41](https://user-images.githubusercontent.com/1709049/233231868-fa4a198c-882b-4692-9325-12be580448bf.png)

It looks pretty distorted.
