### PR TITLE
ESC deadzone

### DIFF
--- a/src/seahawk_rov/seahawk_rov/__init__.py
+++ b/src/seahawk_rov/seahawk_rov/__init__.py
@@ -37,5 +37,6 @@ from .thrust_box_servo import ThrustBoxServo
 # helper functions
 from .helper_functions import float_to_pwm
 from .helper_functions import clamp
+from .helper_functions import deadzone
 
 from .__main__ import main

--- a/src/seahawk_rov/seahawk_rov/helper_functions.py
+++ b/src/seahawk_rov/seahawk_rov/helper_functions.py
@@ -24,14 +24,11 @@ cabrillorobotics@gmail.com
 '''
 
 # linear interpolation helper function
-def float_to_pwm(old_value:float)->int:
+def float_to_pwm(old_value:float, new_min:int=0, new_max:int=3000)->int:
     '''linear interpolate helper function'''
 
     old_min:float = -1.0
     old_max:float = 1.0
-
-    new_min:int = 0
-    new_max:int = 3000
 
     old_range = old_max - old_min
     new_range = new_max - new_min
@@ -56,3 +53,10 @@ def clamp(num, minimum, maximum):
   minimised = min(maximised, maximum)
 
   return minimised
+
+# deadzone helper function
+# if within range set value to something; else do nothing
+def deadzone(num, min, max, value=0):
+   if min <= num <= max:
+      return value
+   return num

--- a/src/seahawk_rov/seahawk_rov/helper_functions.py
+++ b/src/seahawk_rov/seahawk_rov/helper_functions.py
@@ -24,11 +24,14 @@ cabrillorobotics@gmail.com
 '''
 
 # linear interpolation helper function
-def float_to_pwm(old_value:float, new_min:int=0, new_max:int=3000)->int:
+def float_to_pwm(old_value:float)->int:
     '''linear interpolate helper function'''
 
     old_min:float = -1.0
     old_max:float = 1.0
+
+    new_min:int = 0
+    new_max:int = 3000
 
     old_range = old_max - old_min
     new_range = new_max - new_min

--- a/src/seahawk_rov/seahawk_rov/thrust_box_servo.py
+++ b/src/seahawk_rov/seahawk_rov/thrust_box_servo.py
@@ -55,4 +55,4 @@ class ThrustBoxServo:
 
     def receive_thruster(self, message:Float32MultiArray):
         for thruster in self.thruster_map:
-            self.kit.servo[thruster].angle = int(seahawk_rov.float_to_pwm(seahawk_rov.clamp(message.data[thruster], -1.0, 1.0)))
+            self.kit.servo[thruster].angle = int(seahawk_rov.deadzone(seahawk_rov.float_to_pwm(seahawk_rov.clamp(message.data[thruster], -1.0, 1.0), 1250, 1750), 1464, 1536, 1500))

--- a/src/seahawk_rov/seahawk_rov/thrust_box_servo.py
+++ b/src/seahawk_rov/seahawk_rov/thrust_box_servo.py
@@ -55,4 +55,4 @@ class ThrustBoxServo:
 
     def receive_thruster(self, message:Float32MultiArray):
         for thruster in self.thruster_map:
-            self.kit.servo[thruster].angle = int(seahawk_rov.deadzone(seahawk_rov.float_to_pwm(seahawk_rov.clamp(message.data[thruster], -1.0, 1.0), 1250, 1750), 1464, 1536, 1500))
+            self.kit.servo[thruster].angle = int(seahawk_rov.deadzone(seahawk_rov.float_to_pwm(seahawk_rov.clamp(message.data[thruster], -1.0, 1.0)), 1464, 1536, 1500))


### PR DESCRIPTION
~~Looking at BlueRobotics' data table for their T200 thruster, there are actually only so many values under 5 amps. Ciaran already limited the values that could possibly be sent to the ESCs with the servokit library, but there was another issue: the -1,1 float range from /drive/motors was mapped directly to the 0-3000 value range of the ESC, 80% of which we couldn't use at all due to the power draw being more than 5 amps. So, we just pegged the values for 40% of our input range at 1220, and another 40% of our input range at 1780. In other words, only 20% of our range was controllable. This commit improves the accuracy by changing the linear interpolation parameters such that we can actually use most of the values.~~

Furthermore, I've also implemented a deadzone on the hardware side, as according to BlueRobotics, 
> all values **below 300 RPM** are dropped to zero, as **rotation below this value is not consistent** and results in jerky motion and non-constant thrust, power draw, etc.

This is the source of the weird stopping/starting spinning on the thrusters when we have it out of the water.