### PR TITLE
Fix OO I2C classes not working right/at all

### DIFF
--- a/src/seahawk_rov/seahawk_rov/bme280.py
+++ b/src/seahawk_rov/seahawk_rov/bme280.py
@@ -45,17 +45,17 @@ class BME280:
     ):
         self.frame_id = frame_id
 
-        # instanciate the sensor
-        self.bme = adafruit_bme280.Adafruit_BME280_I2C(i2c_bus, i2c_addr)
+        # instantiate the sensor
+        self.bme = adafruit_bme280.Adafruit_BME280_I2C(i2c=i2c_bus, address=i2c_addr)
 
-        # instanciate the publishers
+        # instantiate the publishers
         self.temperature_publisher = node.create_publisher(Temperature, hardware_location + '/' + 'temperature', 10)
         self.humidity_publisher = node.create_publisher(RelativeHumidity, hardware_location + '/' + 'humidity', 10)
         self.pressure_publisher = node.create_publisher(FluidPressure, hardware_location + '/' + 'pressure', 10)
 
     def publish(self):
 
-        # instanciate the messages
+        # instantiate the messages
         msg_temperature = Temperature()
         msg_humidity = RelativeHumidity()
         msg_pressure = FluidPressure()

--- a/src/seahawk_rov/seahawk_rov/bme280.py
+++ b/src/seahawk_rov/seahawk_rov/bme280.py
@@ -66,9 +66,9 @@ class BME280:
         msg_pressure.header.frame_id = self.frame_id
 
         # get sensor data
-        msg_temperature.temperature = self.bme.temperature
-        msg_humidity.relative_humidity = self.bme.humidity
-        msg_pressure.fluid_pressure = self.bme.pressure
+        msg_temperature.temperature = float(self.bme.temperature)
+        msg_humidity.relative_humidity = float(self.bme.humidity)
+        msg_pressure.fluid_pressure = float(self.bme.pressure)
 
         # publish data
         self.temperature_publisher.publish(msg_temperature)

--- a/src/seahawk_rov/seahawk_rov/bno085.py
+++ b/src/seahawk_rov/seahawk_rov/bno085.py
@@ -51,7 +51,7 @@ class BNO085:
         self.publisher = node.create_publisher(Imu, hardware_location + '/' + 'imu', 10)
 
         # instantiate the sensor
-        self.bno = BNO08X_I2C(i2c_bus, i2c_addr)
+        self.bno = BNO08X_I2C(i2c_bus=i2c_bus, address=i2c_addr)
 
         # enable raw data outputs
         self.bno.enable_feature(adafruit_bno08x.BNO_REPORT_GEOMAGNETIC_ROTATION_VECTOR)


### PR DESCRIPTION
Here, I'm fixing the BNO085 because the default parameter order means that we were using the `i2c_addr` as the `reset` boolean. So, I'm explicitly assigning all of the OO constructor parameters directly.
Furthermore, for some in(s)ane and unknowable reason, despite working with and storing the float type internally, these message types try to assert whether the value passed to them is of the float class, rather than the float type. As such, I've put the float type values returned from the BME280 into float classes instead.