### PR TITLE
Fix ethernet unreliability because of eee on Pi4

### DIFF
--- a/setup/roles/rov/files/rc.local
+++ b/setup/roles/rov/files/rc.local
@@ -1,0 +1,3 @@
+#! /bin/bash 
+
+ethtool --set-eee eth0 eee off

--- a/setup/roles/rov/tasks/main.yaml
+++ b/setup/roles/rov/tasks/main.yaml
@@ -56,6 +56,15 @@
     src: user-data
     dest: /boot/user-data
 
+- name: copy rc.local file
+  become: true
+  copy:
+    src: rc.local
+    dest: /etc/rc.local
+    owner: root 
+    group: root 
+    mode: '0755'
+
 - name: disable camera auto detect
   become: true
   lineinfile:


### PR DESCRIPTION
The deck box of last resort and my laptop are both affected by this bug when connected *directly* to the ROV: 

https://github.com/raspberrypi/linux/issues/4289

They do not seem affected when connecting through a switch. The issue is serious enough so that we should consider defensively disabling Energy Efficient Ethernet) on the ROV. 