### PR TITLE
Add launch for second deck box for video

### DIFF
--- a/src/seahawk_deck/launch/deck_video.launch.py
+++ b/src/seahawk_deck/launch/deck_video.launch.py
@@ -1,0 +1,40 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='image_transport',
+            executable='republish',
+            name='republish_front_camera',
+            output='screen',
+            arguments=['h264', 'raw', '--ros-args', '--log-level', 'fatal'],
+            remappings=[
+                ('/in/h264', 'camera/front/h264'),
+                ('/out', 'extra_camera/front/image'),
+            ]
+        ),
+        Node(
+            package='image_transport',
+            executable='republish',
+            name='republish_claw_camera',
+            output='screen',
+            arguments=['h264', 'raw', '--ros-args', '--log-level', 'fatal'],
+            remappings=[
+                ('/in/h264', 'camera/claw/h264'),
+                ('/out', 'extra_camera/claw/image'),
+            ]
+        ),
+        Node(
+            package='image_transport',
+            executable='republish',
+            name='republish_top_camera',
+            output='screen',
+            arguments=['h264', 'raw', '--ros-args', '--log-level', 'fatal'],
+            remappings=[
+                ('/in/h264', 'camera/top/h264'),
+                ('/out', 'extra_camera/top/image'),
+            ]
+        ),
+    ])


### PR DESCRIPTION
A second laptop plugged in to the deck box can be used to grab screenshot.