### PR TITLE
Switch h264 submodule to relative path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/h264_image_transport"]
-	path = src/h264_image_transport
-	url = https://github.com/clydemcqueen/h264_image_transport.git
+  path = src/h264_image_transport
+  url = ../../clydemcqueen/h264_image_transport.git


### PR DESCRIPTION
This allows for any protocol to be used to clone the submodule, rather than just https. It defaults to whatever the parent was cloned with, so if you cloned with ssh, it would clone the submodule with ssh, and if you cloned with https, the submodule would be cloned with https.

This is a subset of the changes made by #169, those changes will be limited to only change the setup folder/submodule instead of also making the h264 submodule a relative path.