### PR TITLE
Devcontainer configuration.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/base:jammy
+
+# Setup packages needed for `make devbox-install`
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install git ansible python3-pip vim

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,3 +3,11 @@ FROM mcr.microsoft.com/devcontainers/base:jammy
 # Setup packages needed for `make devbox-install`
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install git ansible python3-pip vim
+
+# Install the latest devbox playbook
+RUN cd /tmp \
+    && git clone https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023.git \
+    && make -C cabrillo_rov_2023 devbox-install 
+        
+# Put ros2 in the path
+RUN echo '. /opt/ros/humble/setup.bash' >> /home/vscode/.bashrc 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "SeahawkTank",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"build": { "dockerfile": "Dockerfile" },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root",
+
+	//"runArgs": [
+	//	"--network=host"
+	//]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "SeahawkTank",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	// "image": "mcr.microsoft.com/devcontainers/base:jammy",
-	"build": { "dockerfile": "Dockerfile" },
+	"build": { "dockerfile": "Dockerfile" }
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ CATKIN_IGNORE
 COLCON_IGNORE
 
 # vscode dev docker container
-.devcontainer/devcontainer.json
 *.vscode
 
 # From colcon build 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,88 @@
 
 Cabrillo College Robotics Club repo for the MATE ROV 2023 competition
 
-## Software
+## Setup GitHub
 
-ROS 2 Humble Hawksbill (Ubuntu 22.04 LTS)
+In order to use this repository you should have generated SSH keys and uploaded your public key to GitHub. If you have not yet created an SSH key on your machine do the following. **Skip these steps if you have an SSH key in GitHub already**. 
 
-[ROS Documentation](http://docs.ros.org/en/humble/index.html)
+1. Create an SSH key if you don't have one already. 
+    ```console 
+    ssh-keygen -t ed25519
+    ```
+    Use the default location, set a password if you like. 
+1. Copy and paste your public key into GitHub
+    ```console
+    cat ~/.ssh/id_ed25519.pub
+    ```
+    Full instructions for how to add a public key to GitHub can be found in [GitHub's official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account).
 
-## Getting Started 
 
-Check out the [README](./setup/README.md) in the `setup` directory. 
+## Getting Started (Mac and Windows)
+
+If you have a Windows or Mac desktop (or Linux that's not Ubuntu 22.04) you can use Docker and Development Containers in vscode to do local development. This is the fastest and easiest way to get setup and eables you to run and test nodes on your computer. That's good for learning but you won't be able to use the ROS2 network or use devices like a joystick or camera.
+
+1. [Install vscode](https://code.visualstudio.com/)
+1. [Install Docker Desktop](https://www.docker.com/products/docker-desktop/)
+1. Follow the [Dev Containers Tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial)
+
+Now checkout the code in this repository:
+
+1. Check out this repository into your home directory. 
+
+    **These commands work for Terminal on Mac and PowerShell on Windows.**
+    ```console
+    cd 
+    git clone git@github.com:CabrilloRoboticsClub/cabrillo_rov_2023.git
+    cd ~/cabrillo_rov_2023
+    git submodule init 
+    git submodule update
+    ```
+1. Start vscode int the new `cabrillo_rov_2023` directory. Vscode will prompt you to create a dev container. Follow the prompts. Building the container will take 10 to 20 minutes but you only have to do it once. 
+
+1. Create a Terminal in your vscode window with the `Terminal -> New Terminal` menu. 
+1. Build the software in your dev container: 
+
+    **Run this command in the dev container terminal.**
+
+    ```console 
+    make 
+    ```
+
+## Ubuntu 22.04 Desktop Setup 
+
+If you have Ubuntu 22.04 on your desktop you don't need a dev container because you can run everything natively. Only Ubuntu machines will be able to use hardware and communicate with other machines in the ROS2 network. 
+
+1. Install necessary packages (skip this if you're using a removable drive provided by the club)
+    ```console
+    sudo apt update -y && sudo apt install -y git ansible python3-pip vim 
+    ```
+1. Check out this repository into your home directory. 
+    ```console
+    cd 
+    git clone git@github.com:CabrilloRoboticsClub/cabrillo_rov_2023.git
+    cd ~/cabrillo_rov_2023
+    git submodule init 
+    git submodule update
+    ```
+1. Use `make` to install ROS2 and all the necessary packages. 
+    ```console 
+    make devbox-install
+    ```
+    This will take a while! 
+1. Put ROS on your path 
+    ```console
+    echo 'if [ -z "$ROS_DISTRO" ]; then source /opt/ros/humble/setup.bash; fi' >> ~/.bashrc 
+    ```
+1. **Start a new shell** and build the repository
+    ```console
+    make 
+    ```
+
+You Desktop is now a dev box. 
+
+## Setup a Raspberry Pi 4
+
+If you want to setup a Pi to work like the ROV follow the instructions in the [setup directory](./setup/README.md)
 
 ## Building
 
@@ -71,8 +144,8 @@ source install/setup.bash # Choose one that matches your shell.
 Run the Python examples:
 
 ```console
-ros2 run seahawk_rov example_pub
-ros2 run seahawk_rov example_sub
+ros2 run seahawk example_pub
+ros2 run seahawk example_sub
 ```
 
 ## Launching the Kinematics Debug Nodes

--- a/setup/README.md
+++ b/setup/README.md
@@ -2,46 +2,6 @@
 
 This readme will describe how to setup various things.
 
-## Development Box Setup 
-
-Take the following steps to get started. 
-
-1. Install necessary packages (skip this if you're using a removable drive provided by the club)
-    ```console
-    sudo apt update -y && sudo apt install -y git ansible python3-pip vim 
-    ```
-1. Create an SSH key if you don't have one already. 
-    ```console 
-    ssh-keygen -t ed25519
-    ```
-    Use the default location, set a password if you like. 
-1. Copy and paste your public key into GitHub
-    ```console
-    cat ~/.ssh/id_ed25519.pub
-    ```
-    Full instructions for how to add a public key to GitHub can be found in [GitHub's official documentation](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account#adding-a-new-ssh-key-to-your-account).
-1. Check out this repository into your home directory. 
-    ```console
-    cd 
-    git clone git@github.com:CabrilloRoboticsClub/cabrillo_rov_2023.git
-    cd ~/cabrillo_rov_2023
-    git submodule init 
-    git submodule update
-    ```
-1. Use `make` to install ROS2 and all the necessary packages. 
-    ```console 
-    make devbox-install
-    ```
-    This will take a while! 
-1. Put ROS on your path 
-    ```console
-    echo 'if [ -z "$ROS_DISTRO" ]; then source /opt/ros/humble/setup.bash; fi' >> ~/.bashrc 
-    ```
-1. **Start a new shell** and build the repository
-    ```console
-    make 
-    ```
-
 ## Using vscode to Connect to a Pi
 
 The best way to access the Raspberry Pi is using vscode. You can use the access to develop and test nodes that run on the Pi or to just start the ROV during development of deck-side nodes. Assuming you have your devbox setup per the instructions above, perform the following steps to access the Pi. 


### PR DESCRIPTION
This PR adds vscode configuration that will prompt a user to open this workspace in a [develpment container](https://code.visualstudio.com/docs/devcontainers/create-dev-container). A dev container, "lets you use a [Docker container](https://docker.com/) as a full-featured development environment." It requires Docker. **This should enable users on Windows, Mac (x86 or ARM) and Linux to do software development on their own computer.** 

This branch works on my machine but I need someone to test it. If you have a Mac and want to try to get ROS2 working on your machine, here's how to start:

1. [Install vscode](https://code.visualstudio.com/) 
2. [Install Docker Desktop](https://www.docker.com/products/docker-desktop/)
3. Install the Remote Containers vscode plugin 
4. Checkout this branch:
    ```
    git fetch
    git checkout vscode-devcontainer
    ```
6. Start vscode and see what it says! 



 