### PR TITLE
Refactor input_xbox_one node

### DIFF
--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -154,8 +154,7 @@ class InputXboxOne(Node):
         twist_msg.linear.z  = ((controller["neg_linear_z"] - controller["pos_linear_z"]) / 2) / bambi_div # Z (depth)
 
         # Roll is activated at a constant 0.5 throttle if either the left or right button is pressed
-        roll_dir = -1 if controller["neg_angular_x"] else 1
-        twist_msg.angular.x = (roll_dir * 0.5 / bambi_div) if controller["pos_angular_x"] or controller["neg_angular_x"] else 0.0 # R (roll)
+        twist_msg.angular.x = (controller["pos_angular_x"] - controller["neg_angular_x"]) * 0.5 / bambi_div
     
         twist_msg.angular.y = controller["angular_y"]    / bambi_div     # P (pitch) 
         twist_msg.angular.z = -controller["angular_z"]   / bambi_div     # Y (yaw)

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -130,6 +130,7 @@ class InputXboxOne(Node):
         twist_msg = Twist()
         twist_msg.linear.x  = controller["linear_x"]     / bambi_div     # Z (forwards)
         twist_msg.linear.y  = -controller["linear_y"]    / bambi_div     # Y (sideways)
+        twist_msg.linear.z  = ((controller["neg_linear_z"] - controller["pos_linear_z"]) / 2) / bambi_div # Z (depth)
         twist_msg.angular.x = 0.0 # R (roll) (we don"t need roll)
         twist_msg.angular.y = controller["angular_y"]    / bambi_div     # P (pitch) 
         twist_msg.angular.z = -controller["angular_z"]   / bambi_div     # Y (yaw)

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -1,7 +1,7 @@
 """
 input_xbox_one.py
 
-Handle input from an Xbox One controller and output it on /drive/twist
+Handle input from an Xbox One controller
 
 Copyright (C) 2022-2023 Cabrillo Robotics Club
 
@@ -25,7 +25,6 @@ cabrillorobotics@gmail.com
 import sys 
 
 import rclpy
-
 from rclpy.node import Node 
 # from rcl_interfaces.srv import SetParameters
 from geometry_msgs.msg import Twist 
@@ -40,7 +39,7 @@ OFF = 0
 
 class InputXboxOne(Node):
     """
-    Class that implements the joystick input.
+    Class that implements the joystick input
     """
 
     def __init__(self):
@@ -49,8 +48,8 @@ class InputXboxOne(Node):
         """
         super().__init__("input_xbox_one")
         self.subscription = self.create_subscription(Joy, "joy", self.__callback, 10)
-        self.twist_pub = self.create_publisher(Twist, "controller_twist", 10)
-        self.claw_pub = self.create_publisher(Bool, "claw", 10)
+        self.__twist_pub = self.create_publisher(Twist, "controller_twist", 10)
+        self.__claw_pub = self.create_publisher(Bool, "claw", 10)
         
         self.__button_state = {
             # "" :                OFF,        # left_stick_press
@@ -65,6 +64,37 @@ class InputXboxOne(Node):
             # "":                 OFF,        # menu
             # "":                 OFF,        # xbox
         }
+    
+    @staticmethod
+    def __throttle_curve(input: float, curve: int=0):
+        """
+        Applies a throttle curve mapping to the 'input'. A throttle curve allows the user to
+        modify the relationship between the stick position and the actual throttle value sent
+        to the motors
+
+        The throttle curve is selected by passing a number [0, 3] to the 'curve' param
+            0 (default): No throttle curve
+            1: 
+            2: 
+            3: 
+
+        Args:
+            input: The value to remap
+            curve: The type of curve to remap to
+
+        Returns:
+            'input' remapped to fit the specified throttle curve
+        """
+        match curve:
+            case 1:
+                pass
+            case 2:
+                pass
+            case 3:
+                pass
+            case _:
+                return input
+    
 
     def __callback(self, joy_msg: Joy):
         """
@@ -138,14 +168,14 @@ class InputXboxOne(Node):
         twist_msg.angular.z = -controller["angular_z"]   / bambi_div     # Y (yaw)
      
         # Publsih twist message
-        self.twist_pub.publish(twist_msg)
+        self.__twist_pub.publish(twist_msg)
 
         # Create claw message
         claw_msg = Bool()
         claw_msg.data = sticky_button("claw")
 
         # Publish claw message
-        self.claw_pub.publish(claw_msg)
+        self.__claw_pub.publish(claw_msg)
 
 def main(args=None):
     rclpy.init(args=args)

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -88,18 +88,18 @@ class InputXboxOne(Node):
         super().__init__("input_xbox_one")
 
         self.subscription = self.create_subscription(Joy, "joy", self.__callback, 10)
-        self.__twist_pub = self.create_publisher(Twist, "controller_twist", 10)
-        self.__claw_pub = self.create_publisher(Bool, "claw", 10)
+        self.__twist_pub = self.create_publisher(Twist, "desired_twist", 10)
+        self.__claw_pub = self.create_publisher(Bool, "claw_state", 10)
         
         self.__buttons = {
-            # "" :                StickyButton(),        # left_stick_press
-            # "" :                StickyButton(),        # right_stick_press
-            "claw":             StickyButton(),       # a
-            "bambi_mode":       StickyButton(),       # b
-            # "":                 StickyButton(),        # x
-            # "":                 StickyButton(),        # y
-            # "":                 StickyButton(),        # window
-            # "":                 StickyButton(),        # menu
+            # "" :              StickyButton(),         # left_stick_press
+            # "" :              StickyButton(),         # right_stick_press
+            "claw":             StickyButton(),         # a
+            "bambi_mode":       StickyButton(),         # b
+            # "":               StickyButton(),         # x
+            # "":               StickyButton(),         # y
+            # "":               StickyButton(),         # window
+            # "":               StickyButton(),         # menu
         }
 
     def __callback(self, joy_msg: Joy):

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -107,49 +107,6 @@ class InputXboxOne(Node):
             # "":                 StickyButton(),        # window
             # "":                 StickyButton(),        # menu
         }
-    
-        # self.__cur_throttle_curve = 0
-        # self.__throttle_y = []
-        # self.__throttle_x = [0.0, 0.25, 0.50, 0.75, 1.0]
-    
-    # TODO: Fix all this throttle stuff, maybe move it nto its own class?
-    def __throttle_curve(self, input: float, curve: int=0):
-        """
-        Applies a throttle curve to the 'input'. A throttle curve allows the user to
-        modify the relationship between the stick position and the actual throttle value sent
-        to the motors
-
-        The throttle curve is selected by passing a number [0, 2] to the 'curve' param
-            0 (default): No throttle curve
-            1: [0.0, 0.4, 0.7, 0.8, 1.0]
-            2: [0.0, 0.1, 0.2, 0.5, 1.0]
-    
-        Args:
-            input: The value to remap
-            curve: The type of curve to remap to
-
-        Returns:
-            'input' remapped to fit the specified throttle curve
-        """
-        # if curve == self.__cur_throttle_curve:
-        #     pass
-        # else:
-        match curve:
-            case 1:
-                y = [0.0, 0.4, 0.7, 0.8, 1.0]
-            case 2:
-                y = [0.0, 0.1, 0.2, 0.5, 1.0]
-            case _:
-                return input
-
-        x = [0.0, 0.25, 0.50, 0.75, 1.0]
-
-        # Determine if we need to multiply by a negative to indicate the direction
-        direction = -1 if input < 0 else 1
-
-        # CubicSpline creates a cubic spline interpolation given a list of x and y values
-        # It returns an interpolated function
-        return direction * CubicSpline(x, y)(abs(input))
 
     def __callback(self, joy_msg: Joy):
         """
@@ -198,7 +155,7 @@ class InputXboxOne(Node):
 
         # Create twist message
         twist_msg = Twist()
-        twist_msg.linear.x  = controller["linear_x"]     / bambi_div      # Z (forwards)
+        twist_msg.linear.x  = controller["linear_x"]     / bambi_div     # Z (forwards)
         twist_msg.linear.y  = -controller["linear_y"]    / bambi_div     # Y (sideways)
         twist_msg.linear.z  = ((controller["neg_linear_z"] - controller["pos_linear_z"]) / 2) / bambi_div # Z (depth)
 

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -144,20 +144,27 @@ class InputXboxOne(Node):
             "reset":            joy_msg.buttons[8], # xbox
         }
 
-        # Bambi mode cuts all twist values in half for more precise movements
-        bambi_div = 2 if self.__buttons["bambi_mode"].check_state(controller["bambi_mode"]) else 1
 
         # Create twist message
         twist_msg = Twist()
-        twist_msg.linear.x  = controller["linear_x"]     / bambi_div     # Z (forwards)
-        twist_msg.linear.y  = -controller["linear_y"]    / bambi_div     # Y (sideways)
-        twist_msg.linear.z  = ((controller["neg_linear_z"] - controller["pos_linear_z"]) / 2) / bambi_div # Z (depth)
+        twist_msg.linear.x  = controller["linear_x"] # Z (forwards)
+        twist_msg.linear.y  = -controller["linear_y"] # Y (sideways)
+        twist_msg.linear.z  = ((controller["neg_linear_z"] - controller["pos_linear_z"]) / 2) # Z (depth)
 
         # Roll is activated at a constant 0.5 throttle if either the left or right button is pressed
-        twist_msg.angular.x = (controller["pos_angular_x"] - controller["neg_angular_x"]) * 0.5 / bambi_div
+        twist_msg.angular.x = (controller["pos_angular_x"] - controller["neg_angular_x"]) * 0.5
     
-        twist_msg.angular.y = controller["angular_y"]    / bambi_div     # P (pitch) 
-        twist_msg.angular.z = -controller["angular_z"]   / bambi_div     # Y (yaw)
+        twist_msg.angular.y = controller["angular_y"] # P (pitch)
+        twist_msg.angular.z = -controller["angular_z"] # Y (yaw)
+
+        # Bambi mode cuts all twist values in half for more precise movements
+        if self.__buttons["bambi_mode"].check_state(controller["bambi_mode"]):
+            twist_msg.linear.x /= 2
+            twist_msg.linear.y /= 2
+            twist_msg.linear.z /= 2
+            twist_msg.angular.x /= 2
+            twist_msg.angular.y /= 2
+            twist_msg.angular.z /= 2
      
         # Publish twist message
         self.__twist_pub.publish(twist_msg)

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -25,7 +25,7 @@ cabrillorobotics@gmail.com
 # For reading argv
 import sys 
 
-# Ros client libary imports
+# ROS client libary imports
 import rclpy
 from rclpy.node import Node 
 

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -70,6 +70,14 @@ class StickyButton():
             self.__feature_state = not self.__feature_state
         return bool(self.__feature_state)
 
+    def reset(self):
+        """
+        Resets button state to origional configuration
+        """
+        self.__feature_state = OFF
+        self.__track_state = 0b0000
+
+
 class InputXboxOne(Node):
     """
     Class that implements the joystick input
@@ -92,17 +100,15 @@ class InputXboxOne(Node):
             "bambi_mode":       StickyButton(),       # b
             # "":                 StickyButton(),        # x
             # "":                 StickyButton(),        # y
-            # "":                 StickyButton(),        # left_bumper
-            # "":                 StickyButton(),        # right_bumper
             # "":                 StickyButton(),        # window
             # "":                 StickyButton(),        # menu
-            # "":                 StickyButton(),        # xbox
         }
     
         # self.__cur_throttle_curve = 0
         # self.__throttle_y = []
         # self.__throttle_x = [0.0, 0.25, 0.50, 0.75, 1.0]
     
+    # TODO: Fix all this throttle stuff, maybe move it nto its own class?
     def __throttle_curve(self, input: float, curve: int=0):
         """
         Applies a throttle curve to the 'input'. A throttle curve allows the user to
@@ -158,11 +164,11 @@ class InputXboxOne(Node):
             # Left stick
             "linear_y":         joy_msg.axes[0],                # left_stick_x
             "linear_x":         joy_msg.axes[1],                # left_stick_y
-            # "":                 joy_msg.buttons[9],             # left_stick_press
+            # "":               joy_msg.buttons[9],             # left_stick_press
             # Right stick
             "angular_z":        joy_msg.axes[3],                # right_stick_x
             "angular_y":        joy_msg.axes[4],                # right_stick_y
-            # "":                 joy_msg.buttons[10],            # right_stick_press
+            # "":               joy_msg.buttons[10],            # right_stick_press
             # Triggers
             "neg_linear_z":     joy_msg.axes[2],                # left_trigger
             "pos_linear_z":     joy_msg.axes[5],                # right_trigger
@@ -172,15 +178,15 @@ class InputXboxOne(Node):
             # "":                 int(max(joy_msg.axes[6], 0)),   # dpad_left     
             # "":                 int(-min(joy_msg.axes[6], 0)),  # dpad_right
             # Buttons
-            "claw":             joy_msg.buttons[0], # a
-            "bambi_mode":       joy_msg.buttons[1], # b
-            # "":                 joy_msg.buttons[2], # x
-            # "":                 joy_msg.buttons[3], # y
-            # "":                 joy_msg.buttons[4], # left_bumper
-            # "":                 joy_msg.buttons[5], # right_bumper
-            # "":                 joy_msg.buttons[6], # window
-            # "":                 joy_msg.buttons[7], # menu
-            # "":                 joy_msg.buttons[8], # xbox
+            "claw":                         joy_msg.buttons[0], # a
+            "bambi_mode":                   joy_msg.buttons[1], # b
+            # "":                           joy_msg.buttons[2], # x
+            # "":                           joy_msg.buttons[3], # y
+            "roll_counter_clockwise":       joy_msg.buttons[4], # left_bumper
+            "roll_clockwise":               joy_msg.buttons[5], # right_bumper
+            # "":                           joy_msg.buttons[6], # window
+            # "":                           joy_msg.buttons[7], # menu
+            "reset":                        joy_msg.buttons[8], # xbox
         }
 
         # Bambi mode cuts all twist values in half for more precise movements
@@ -206,6 +212,10 @@ class InputXboxOne(Node):
 
         # Publish claw message
         self.__claw_pub.publish(claw_msg)
+
+        # If the x-box button is pressed, all settings get reset to default configurations
+        if controller["reset"]:
+            self.__buttons["bambi_mode"].reset()
 
 
 def main(args=None):

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -45,7 +45,7 @@ class StickyButton():
         """
         Initialize 'StickyButton' object
         """
-        self.__feature_state = False    # Is the feature this button controlls on (True) or off (False)
+        self.__feature_state = False    # Is the feature this button controls on (True) or off (False)
         self.__track_state = 0b0000     # Tracks the last four states of the button using bits
     
     def check_state(self, cur_button_state: bool) -> bool:
@@ -70,7 +70,7 @@ class StickyButton():
 
     def reset(self):
         """
-        Resets button state to origional configuration
+        Resets button state to original configuration
         """
         self.__feature_state = False
         self.__track_state = 0b0000
@@ -92,14 +92,14 @@ class InputXboxOne(Node):
         self.__claw_pub = self.create_publisher(Bool, "claw_state", 10)
         
         self.__buttons = {
-            # "" :              StickyButton(),         # left_stick_press
-            # "" :              StickyButton(),         # right_stick_press
-            "claw":             StickyButton(),         # a
-            "bambi_mode":       StickyButton(),         # b
-            # "":               StickyButton(),         # x
-            # "":               StickyButton(),         # y
-            # "":               StickyButton(),         # window
-            # "":               StickyButton(),         # menu
+            # "" :              StickyButton(),     # left_stick_press
+            # "" :              StickyButton(),     # right_stick_press
+            "claw":             StickyButton(),     # a
+            "bambi_mode":       StickyButton()      # b
+            # "":               StickyButton(),     # x
+            # "":               StickyButton(),     # y
+            # "":               StickyButton(),     # window
+            # "":               StickyButton(),     # menu
         }
 
     def __callback(self, joy_msg: Joy):
@@ -128,20 +128,20 @@ class InputXboxOne(Node):
             "neg_linear_z":     joy_msg.axes[2],                # left_trigger
             "pos_linear_z":     joy_msg.axes[5],                # right_trigger
             # Dpad
-            # "":                 int(max(joy_msg.axes[7], 0)),   # dpad_up
-            # "":                 int(-min(joy_msg.axes[7], 0)),  # dpad_down
-            # "":                 int(max(joy_msg.axes[6], 0)),   # dpad_left     
-            # "":                 int(-min(joy_msg.axes[6], 0)),  # dpad_right
+            # "":               int(max(joy_msg.axes[7], 0)),   # dpad_up
+            # "":               int(-min(joy_msg.axes[7], 0)),  # dpad_down
+            # "":               int(max(joy_msg.axes[6], 0)),   # dpad_left     
+            # "":               int(-min(joy_msg.axes[6], 0)),  # dpad_right
             # Buttons
-            "claw":                         joy_msg.buttons[0], # a
-            "bambi_mode":                   joy_msg.buttons[1], # b
-            # "":                           joy_msg.buttons[2], # x
-            # "":                           joy_msg.buttons[3], # y
-            "pos_angular_x":                joy_msg.buttons[4], # left_bumper
-            "neg_angular_x":                joy_msg.buttons[5], # right_bumper
-            # "":                           joy_msg.buttons[6], # window
-            # "":                           joy_msg.buttons[7], # menu
-            "reset":                        joy_msg.buttons[8], # xbox
+            "claw":             joy_msg.buttons[0], # a
+            "bambi_mode":       joy_msg.buttons[1], # b
+            # "":               joy_msg.buttons[2], # x
+            # "":               joy_msg.buttons[3], # y
+            "pos_angular_x":    joy_msg.buttons[4], # left_bumper
+            "neg_angular_x":    joy_msg.buttons[5], # right_bumper
+            # "":               joy_msg.buttons[6], # window
+            # "":               joy_msg.buttons[7], # menu
+            "reset":            joy_msg.buttons[8], # xbox
         }
 
         # Bambi mode cuts all twist values in half for more precise movements

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -58,9 +58,9 @@ class StickyButton():
         Returns:
             True if the button is toggled on, False if off
         """
-        # Append the current button state to the tracker then remove the leftmost bit
+        # Append the current button state to the tracker then removes all but rightmost byte
         # such that self.__track_state records the most recent four states of the button
-        self.__track_state = (self.__track_state << 1 | cur_button_state) & 0x0F
+        self.__track_state = (self.__track_state << 1 | cur_button_state) & 0b1111
 
         # Account for bounce by making sure the last four recorded states
         # appear to represent a button press. If so, update the feature state

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -37,55 +37,31 @@ from sensor_msgs.msg import Joy
 ON = 1
 OFF = 0
 
-class Input(Node):
+class InputXboxOne(Node):
     """
     Class that implements the joystick input.
     """
 
     def __init__(self):
         """
-        Initialize 'input_xbox_one node'
+        Initialize 'input_xbox_one' node
         """
         super().__init__("input_xbox_one")
         self.subscription = self.create_subscription(Joy, "joy", self.__callback, 10)
         self.twist_pub = self.create_publisher(Twist, "controller_twist", 10)
         
         self.__prev_button_state = {
-            "left_stick_press" :    OFF,
-            "right_stick_press" :   OFF,
-            "a":                    OFF,
-            "b":                    OFF,
-            "x":                    OFF,
-            "y":                    OFF,
-            "left_bumper":          OFF,
-            "right_bumper":         OFF,
-            "window":               OFF,
-            "menu":                 OFF,
-            "xbox":                 OFF,
-        }
-
-        self.__layout = {
-            "linear_y":         "left_stick_x",     # Y (sideways)
-            "linear_x":         "left_stick_y",     # X (forwards)
-            # unimplemented:    "left_stick_press",
-            "angular_z":        "right_stick_x",    # Y (yaw)
-            "angular_y":        "right_stick_y",    # P (pitch)
-            # unimplemented:    "right_stick_press",
-            # unimplemented:    "left_trigger",
-            # unimplemented:    "right_trigger",
-            # unimplemented:    "dpad_up",
-            # unimplemented:    "dpad_down",
-            # unimplemented:    "dpad_left",
-            # unimplemented:    "dpad_right",
-            # unimplemented:    "a",
-            "bambi_mode":       "b",
-            # unimplemented:    "x",
-            # unimplemented:    "y",
-            # unimplemented:    "left_bumper",
-            # unimplemented:    "right_bumper",
-            # unimplemented:    "window",
-            # unimplemented:    "menu",
-            # unimplemented:    "xbox",
+            # "" :                OFF,        # left_stick_press
+            # "" :                OFF,        # right_stick_press
+            # "":                 OFF,        # a
+            "bambi_mode":       OFF,        # b
+            # "":                 OFF,        # x
+            # "":                 OFF,        # y
+            # "":                 OFF,        # left_bumper
+            # "":                 OFF,        # right_bumper
+            # "":                 OFF,        # window
+            # "":                 OFF,        # menu
+            # "":                 OFF,        # xbox
         }
 
     def __callback(self, joy_msg: Joy):
@@ -94,7 +70,7 @@ class Input(Node):
         the direction (linear and angular x, y, z) and percent of max speed the pilot wants the robot to move
 
         Args:
-            joy_msg: Message of type "Joy" from the joy topic
+            joy_msg: Message of type 'Joy' from the joy topic
         """
         # Debug output of joy topic
         self.get_logger().debug(f"Joystick axes: {joy_msg.axes} buttons: {joy_msg.buttons}")
@@ -102,53 +78,53 @@ class Input(Node):
         # Map the values sent from the joy message to useful names
         controller = {
             # Left stick
-            "left_stick_x":     -joy_msg.axes[0],
-            "left_stick_y":     joy_msg.axes[1],
-            "left_stick_press": joy_msg.buttons[9],
+            "linear_y":         -joy_msg.axes[0],               # left_stick_x
+            "linear_x":         joy_msg.axes[1],                # left_stick_y
+            "":                 joy_msg.buttons[9],             # left_stick_press
             # Right stick
-            "right_stick_x":    -joy_msg.axes[3],
-            "right_stick_y":    joy_msg.axes[4],
-            "right_stick_press":joy_msg.buttons[10],
+            "angular_z":        -joy_msg.axes[3],               # right_stick_x
+            "angular_y":        joy_msg.axes[4],                # right_stick_y
+            "":                 joy_msg.buttons[10],            # right_stick_press
             # Triggers
-            "left_trigger":     joy_msg.axes[2],
-            "right_trigger":    joy_msg.axes[5],
+            # "":                 joy_msg.axes[2],                # left_trigger
+            # "":                 joy_msg.axes[5],                # right_trigger
             # Dpad
-            "dpad_up":          int(max(joy_msg.axes[7], 0)),
-            "dpad_down":        int(-min(joy_msg.axes[7], 0)),
-            "dpad_left":        int(max(joy_msg.axes[6], 0)),
-            "dpad_right":       int(-min(joy_msg.axes[6], 0)),
+            # "":                 int(max(joy_msg.axes[7], 0)),   # dpad_up
+            # "":                 int(-min(joy_msg.axes[7], 0)),  # dpad_down
+            # "":                 int(max(joy_msg.axes[6], 0)),   # dpad_left     
+            # "":                 int(-min(joy_msg.axes[6], 0)),  # dpad_right
             # Buttons
-            "a":                joy_msg.buttons[0],
-            "b":                joy_msg.buttons[1],
-            "x":                joy_msg.buttons[2],
-            "y":                joy_msg.buttons[3],
-            "left_bumper":      joy_msg.buttons[4],
-            "right_bumper":     joy_msg.buttons[5],
-            "window":           joy_msg.buttons[6],
-            "menu":             joy_msg.buttons[7],
-            "xbox":             joy_msg.buttons[8],
+            # "":                 joy_msg.buttons[0], # a
+            "bambi_mode":       joy_msg.buttons[1], # b
+            # "":                 joy_msg.buttons[2], # x
+            # "":                 joy_msg.buttons[3], # y
+            # "":                 joy_msg.buttons[4], # left_bumper
+            # "":                 joy_msg.buttons[5], # right_bumper
+            # "":                 joy_msg.buttons[6], # window
+            # "":                 joy_msg.buttons[7], # menu
+            # "":                 joy_msg.buttons[8], # xbox
         }
         
         # ********************* Bambi mode *********************
         # Bambi mode cuts all twist values in half for more precise movements
         # Bambi mode is 'sticky', meaning a button is pressed to turn it on, and pressed again to turn it off
-        bambi_div = 2 if self.__prev_button_state[self.__layout["bambi"]] == OFF and controller[self.__layout["linear_x"]] == ON else 1
-        self.__prev_button_state[self.__layout["bambi"]] = controller[self.__layout["bambi"]]
+        bambi_div = 2 if self.__prev_button_state["bambi_mode"] == OFF and controller["bambi_mode"] == ON else 1
+        self.__prev_button_state["bambi_mode"] = controller["bambi_mode"]
 
         # **************** Create twist message ****************
         twist_msg = Twist()
-        twist_msg.linear.x  = controller[self.__layout["linear_x"]]     / bambi_div     # Z (forwards)
-        twist_msg.linear.y  = -controller[self.__layout["linear_y"]]    / bambi_div     # Y (sideways)
+        twist_msg.linear.x  = controller["linear_x"]     / bambi_div     # Z (forwards)
+        twist_msg.linear.y  = -controller["linear_y"]    / bambi_div     # Y (sideways)
         # twist_msg.linear.z  = (controller["left_trigger"] - controller["right_trigger"]) / 2 # Z (depth) What????
         twist_msg.angular.x = 0.0 # R (roll) (we don"t need roll)
-        twist_msg.angular.y = controller[self.__layout["angular_y"]]    / bambi_div     # P (pitch) 
-        twist_msg.angular.z = -controller[self.__layout["angular_z"]]   / bambi_div     # Y (yaw)
+        twist_msg.angular.y = controller["angular_y"]    / bambi_div     # P (pitch) 
+        twist_msg.angular.z = -controller["angular_z"]   / bambi_div     # Y (yaw)
      
         self.twist_pub.publish(twist_msg)
 
 def main(args=None):
     rclpy.init(args=args)
-    rclpy.spin(Input())
+    rclpy.spin(InputXboxOne())
     rclpy.shutdown()
    
 

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -22,23 +22,17 @@ Cabrillo Robotics Club
 6500 Soquel Drive Aptos, CA 95003
 cabrillorobotics@gmail.com
 """
+# For reading argv
 import sys 
 
+# Ros client libary imports
 import rclpy
 from rclpy.node import Node 
-# from rcl_interfaces.srv import SetParameters
+
+# ROS messages imports
 from geometry_msgs.msg import Twist 
 from sensor_msgs.msg import Joy
 from std_msgs.msg import Bool
-
-from scipy.interpolate import CubicSpline
-# from std_msgs.msg import Int8MultiArray
-# from std_msgs.msg import Float32
-# from rclpy.parameter import Parameter
-
-
-ON = 1
-OFF = 0
 
 
 class StickyButton():
@@ -51,8 +45,8 @@ class StickyButton():
         """
         Initialize 'StickyButton' object
         """
-        self.__feature_state = OFF
-        self.__track_state = 0b0000
+        self.__feature_state = False    # Is the feature this button controlls on (True) or off (False)
+        self.__track_state = 0b0000     # Tracks the last four states of the button using bits
     
     def check_state(self, cur_button_state: bool) -> bool:
         """
@@ -69,16 +63,16 @@ class StickyButton():
         self.__track_state = (self.__track_state << 1 | cur_button_state) & 0x0F
 
         # Account for bounce by making sure the last four recorded states
-        # appear to represent a button press
+        # appear to represent a button press. If so, update the feature state
         if self.__track_state == 0b0011:
             self.__feature_state = not self.__feature_state
-        return bool(self.__feature_state)
+        return self.__feature_state
 
     def reset(self):
         """
         Resets button state to origional configuration
         """
-        self.__feature_state = OFF
+        self.__feature_state = False
         self.__track_state = 0b0000
 
 

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -51,7 +51,6 @@ class StickyButton():
         """
         Initialize 'StickyButton' object
         """
-        self.__prev_button_state = OFF
         self.__feature_state = OFF
     
     def check_state(self, cur_button_state: bool) -> bool:
@@ -64,7 +63,7 @@ class StickyButton():
         Returns:
             True if the button is toggled on, False if off
         """
-        if cur_button_state == ON and self.__prev_button_state == OFF:
+        if cur_button_state == ON:
             self.__feature_state = not self.__feature_state
         return bool(self.__feature_state)
 
@@ -79,6 +78,7 @@ class InputXboxOne(Node):
         Initialize 'input_xbox_one' node
         """
         super().__init__("input_xbox_one")
+
         self.subscription = self.create_subscription(Joy, "joy", self.__callback, 10)
         self.__twist_pub = self.create_publisher(Twist, "controller_twist", 10)
         self.__claw_pub = self.create_publisher(Bool, "claw", 10)
@@ -184,6 +184,8 @@ class InputXboxOne(Node):
         # Bambi mode cuts all twist values in half for more precise movements
         bambi_div = 2 if self.__buttons["bambi_mode"].check_state(controller["bambi_mode"]) else 1
 
+        self.get_logger().info(f"{bambi_div}")
+
         # Create twist message
         twist_msg = Twist()
         twist_msg.linear.x  = controller["linear_x"]     / bambi_div      # Z (forwards)
@@ -208,7 +210,7 @@ def main(args=None):
     rclpy.init(args=args)
     rclpy.spin(InputXboxOne())
     rclpy.shutdown()
-   
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -52,10 +52,11 @@ class StickyButton():
         Initialize 'StickyButton' object
         """
         self.__feature_state = OFF
+        self.__track_state = 0b0000
     
     def check_state(self, cur_button_state: bool) -> bool:
         """
-        Checks if a button is toggled on or off and updates internal state
+        Checks if a button is toggled on or off and accounts for debouncing
 
         Args:
             cur_button_state: Current state of the button provided by the controller
@@ -63,10 +64,11 @@ class StickyButton():
         Returns:
             True if the button is toggled on, False if off
         """
-        if cur_button_state == ON:
+        self.__track_state = (self.__track_state << 1 | cur_button_state) & 0x0F
+
+        if self.__track_state == 0b0011:
             self.__feature_state = not self.__feature_state
         return bool(self.__feature_state)
-
 
 class InputXboxOne(Node):
     """

--- a/src/seahawk/seahawk_deck/input_xbox_one.py
+++ b/src/seahawk/seahawk_deck/input_xbox_one.py
@@ -63,7 +63,8 @@ class StickyButton():
         self.__track_state = (self.__track_state << 1 | cur_button_state) & 0b1111
 
         # Account for bounce by making sure the last four recorded states
-        # appear to represent a button press. If so, update the feature state
+        # appear to represent a button press. A debounced button press is defined as two recorded
+        # consecutive off states followed by two on states. If the button is pressed, update the feature state
         if self.__track_state == 0b0011:
             self.__feature_state = not self.__feature_state
         return self.__feature_state


### PR DESCRIPTION
This cleans up the controller input code from last year to be more readable and less redundant. Also added control for roll and a reset button.

### Significant changes
- Some of the code for handling "sticky buttons" was redundant. This version abstracts a what were multiple variables to handle the button/feature states and redundant code to a dictionary of `StickyButton` objects. The `StickyButton` class handles initializing a `StickyButton`'s internal tracking variables, checking and setting the feature state with a function, and a reset function.
- When testing the code for the buttons, they appeared to be unreliable. This was determined by @mike-matera  to be due to button bouncing. Debounce code was added to the `StickyButton` to eliminate this issue
- The left and right buttons (`LB` and `RB`) on the controller now control roll
- The `x-box` button resets all input settings to the default state

### General code cleanup
- Added python-style doc strings and lots of comments
- Changed code styling to match official python guidelines
- Removed unused imports
- Changed `controller` dictionary keys to be the functionality name rather than the button name to make code more readable
- Changed class name to match the node name 
- Changed names of topics to be more descriptive 
- Changed claw message type to be a Bool rather than an array (because at the moment we only have one claw)
- Changed the button which controls "bambi mode" to be the `B` button (B like bambi I guess)