### PR TITLE
Created input_keyboard node

### DIFF
--- a/src/seahawk/launch/deck.launch.py
+++ b/src/seahawk/launch/deck.launch.py
@@ -83,6 +83,12 @@ def generate_launch_description():
             output='screen'
         ),
         Node(
+            package='seahawk',
+            executable='input_keyboard',
+            name='input_keyboard',
+            output='screen'
+        ),
+        Node(
             package='joy',
             executable='joy_node',
             name='joy_node',

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -25,25 +25,20 @@ cabrillorobotics@gmail.com
 '''
 import sys,tty,os,termios
 
-def getkey():
-    # Get current user terminal settings and save them for later
-    old_settings = termios.tcgetattr(sys.stdin)
+ # Get current user terminal settings and save them for later
+old_settings = termios.tcgetattr(sys.stdin)
 
-    # Enable cbreak mode. In cbreak mode characters typed by the user are immediately available
-    # to the program. This way we can extract keys without the user needing to press enter
-    tty.setcbreak(sys.stdin.fileno())
-
-    try:
-        # Read at most one byte (the length of one character) from stdin and decode it
-        return os.read(sys.stdin.fileno(), 1).decode()
-    finally:
-        # Reset to original terminal settings
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+# Enable cbreak mode. In cbreak mode characters typed by the user are immediately available
+# to the program. This way we can extract keys without the user needing to press enter
+tty.setcbreak(sys.stdin.fileno())
 
 try:
     while True:
-        k = getkey()
+        # Read at most one byte (the length of one character) from stdin and decode it
+        k = os.read(sys.stdin.fileno(), 1).decode()
         print(k)
 except (KeyboardInterrupt, SystemExit):
+    # Reset to original terminal settings
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
     # Make terminal sane again upon program exit
     os.system('stty sane')

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+'''
+input_keyboard.py
+
+Take input from the keyboard and republish it to topic
+
+Copyright (C) 2022-2023 Cabrillo Robotics Club
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Cabrillo Robotics Club
+6500 Soquel Drive Aptos, CA 95003
+cabrillorobotics@gmail.com
+'''
+import sys,tty,os,termios
+
+def getkey():
+    # Get current user terminal settings and save them for later
+    old_settings = termios.tcgetattr(sys.stdin)
+
+    # Enable cbreak mode. In cbreak mode characters typed by the user are immediately available
+    # to the program. This way we can extract keys without the user needing to press enter
+    tty.setcbreak(sys.stdin.fileno())
+
+    try:
+        # Read at most one byte (the length of one character) from stdin and decode it
+        return os.read(sys.stdin.fileno(), 1).decode()
+    finally:
+        # Reset to original terminal settings
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
+
+try:
+    while True:
+        k = getkey()
+        print(k)
+except (KeyboardInterrupt, SystemExit):
+    # Make terminal sane again upon program exit
+    os.system('stty sane')

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -22,9 +22,6 @@ Cabrillo Robotics Club
 6500 Soquel Drive Aptos, CA 95003
 cabrillorobotics@gmail.com
 """
-# For argv
-import sys
-
 # ROS client library
 import rclpy
 from rclpy.node import Node 

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -66,20 +66,25 @@ def main(args=None):
             # Get the key entered by the user
             key = get_key(orig_settings)
 
+            # If ctrl-c break
+            if key == "\x03":
+                break
+
             # Create and publish message
             msg.data = str(key)
             pub.publish(msg)
             print(msg.data)
     except Exception as error_msg:
         node.get_logger().info(error_msg)
-    finally:
-        rclpy.shutdown()
-        spinner.join()
-        # Reset to original terminal settings
-        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, orig_settings)
 
-        # Make terminal sane again upon program exit
-        os.system("stty sane")
+    rclpy.shutdown()
+    spinner.join()
+    
+    # Reset to original terminal settings
+    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, orig_settings)
+
+    # Make terminal sane again upon program exit
+    os.system("stty sane")
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -43,19 +43,19 @@ class InputKeyboard(Node):
 
     def __init__(self, settings):
         """
-        Initialize `input_keyboard` node
+        Initialize 'input_keyboard' node
         """
         super().__init__("input_keyboard")
     
-        # Create publisher to topic `key_press`
-        self.__key_pub = self.create_publisher(String, "key_stroke", 10)
+        # Create publisher to topic 'key_press'
+        self.__key_pub = self.create_publisher(String, "keystroke", 10)
 
         # Get current user terminal settings and save them for later
         self.__settings = settings
     
     def __get_key(self) -> str:
         """
-        Extracts a single key stroke from the user
+        Extracts a single keystroke from the user
 
         Returns:
             String of the name of the key which was pressed
@@ -80,7 +80,7 @@ class InputKeyboard(Node):
         """
         key = self.__get_key()
 
-        # If ctrl-c raise `KeyboardInterrupt`
+        # If 'ctrl-c' raise 'KeyboardInterrupt'
         if key == "\x03":
             raise KeyboardInterrupt("Terminated the process with ctrl-c")
         
@@ -106,7 +106,7 @@ def main(args=None):
 
     try:
         while True:
-            # While the user has not entered ctrl-c, wait for keystrokes and publish them
+            # While the user has not entered 'ctrl-c', wait for keystrokes and publish them
             node.pub_callback()
     except KeyboardInterrupt as error_msg:
         print(error_msg)

--- a/src/seahawk/seahawk_deck/input_keyboard.py
+++ b/src/seahawk/seahawk_deck/input_keyboard.py
@@ -48,7 +48,7 @@ class InputKeyboard(Node):
         super().__init__("input_keyboard")
     
         # Create publisher to topic `key_press`
-        self.__key_pub = self.create_publisher(String, "key_press", 10)
+        self.__key_pub = self.create_publisher(String, "key_stroke", 10)
 
         # Get current user terminal settings and save them for later
         self.__settings = settings

--- a/src/seahawk/setup.py
+++ b/src/seahawk/setup.py
@@ -26,6 +26,7 @@ setup(
         'console_scripts': [
             "thrust=seahawk_deck.thrust:main",
             "input_xbox_one=seahawk_deck.input_xbox_one:main",
+            "input_keyboard=seahawk_deck.input_keyboard:main",
             "rviz_markers=seahawk_deck.rviz_markers:main",
             'seahawk_rov = seahawk_rov:main'
         ],


### PR DESCRIPTION
### Summary
The `input_keyboard` node provides functionality for reading and publishing active keystrokes with ROS2. The node actively listens for keystrokes and immediately publishes them to the `keystroke` topic.

### Reason for merge 
It would be beneficial to have additional buttons beyond the xbox controller to control additional features and settings on the robot. This node was written because ROS2 does not provide builtin support for reading and republishing keystrokes, beyond [teleop_twist_keyboard](https://github.com/ros-teleop/teleop_twist_keyboard) which creates a twist message rather than publishing individual keystrokes.

### Chosen implementation reasoning
After some research, I found three possible ways of reading a user's keystrokes actively (without pressing enter). These were the python [curses](https://docs.python.org/3/howto/curses.html) library, the [keyboard](https://pypi.org/project/keyboard/) library and the method used in `teleop_twist_keyboard` which changes the terminal settings. `curses`  overlays a screen on top of your terminal which is not what we want. Someone on StackOverflow mentioned that `keyboard` used a lot of CPU which would not be ideal. This left changing the settings on the terminal. The final implementation of `input_keyboard` uses similar ideas to that in `teleop_twist_keyboard` but simplified and abstracted to a class.