### PR TITLE
Change name of repo to seahawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cabrillo ROV 2023
+# SeaHawk
 
 Cabrillo College Robotics Club repo for the MATE ROV 2023 competition. This README file has information to get you started developing the robot. 
 
@@ -39,8 +39,8 @@ To get the code in this repository on your computer, dev box or RPi you should r
 
     ```console
     cd 
-    git clone git@github.com:CabrilloRoboticsClub/cabrillo_rov_2023.git
-    cd ~/cabrillo_rov_2023
+    git clone git@github.com:CabrilloRoboticsClub/seahawk.git
+    cd ~/seahawk
     git submodule init 
     git submodule update
     ```
@@ -54,7 +54,7 @@ If you have a Windows or Mac desktop (or Linux that's not Ubuntu 22.04) you can 
 1. [Install vscode](https://code.visualstudio.com/)
 1. [Install Docker Desktop](https://www.docker.com/products/docker-desktop/)
 1. Follow the [Dev Containers Tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial)
-1. In vscode open the `cabrillo_rov_2023` directory that you checked out using the "Checkout the Code" procedure above with the `File -> Open Folder` menu. Vscode will prompt you to create a dev container. Follow the prompts. Building the container could take 10 to 20 minutes but you only have to do it once. 
+1. In vscode open the `seahawk` directory that you checked out using the "Checkout the Code" procedure above with the `File -> Open Folder` menu. Vscode will prompt you to create a dev container. Follow the prompts. Building the container could take 10 to 20 minutes but you only have to do it once. 
 1. Create a Terminal in your vscode window with the `Terminal -> New Terminal` menu. 
 1. Build the software in your dev container: 
 
@@ -67,7 +67,7 @@ If you have a Windows or Mac desktop (or Linux that's not Ubuntu 22.04) you can 
 Alternatively, if you don't want to use the container inside of VSCode, you can run
 ```console
 docker build -t ros2-container:<tag> .devcontainer
-docker run --user vscode -v .:/home/vscode/cabrillo_rov_2023 --network host -it ros2-container:<tag>
+docker run --user vscode -v .:/home/vscode/seahawk --network host -it ros2-container:<tag>
 ```
 
 ## Ubuntu 22.04 Desktop Setup 
@@ -121,8 +121,8 @@ Once you have SSHed into the new Pi image run the ROV specific playbooks:
 1. Check out this repository into your home directory. 
     ```console
     cd 
-    git clone https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023.git
-    cd ~/cabrillo_rov_2023
+    git clone https://github.com/CabrilloRoboticsClub/seahawk.git
+    cd ~/seahawk
     git submodule init 
     git submodule update
     ```
@@ -175,8 +175,8 @@ The best way to access the Raspberry Pi for software development is using vscode
 
     ```console 
     cd
-    git clone git@github.com:CabrilloRoboticsClub/cabrillo_rov_2023.git
-    cd ~/cabrillo_rov_2023
+    git clone git@github.com:CabrilloRoboticsClub/seahawk.git
+    cd ~/seahawk
     git submodule init 
     git submodule update
     ```
@@ -198,7 +198,7 @@ The best way to access the Raspberry Pi for software development is using vscode
 1. Build the ROS project
 
     ```console 
-    cd ~/cabrillo_rov_2023
+    cd ~/seahawk
     make
     ```
 

--- a/doc/dev_notes.md
+++ b/doc/dev_notes.md
@@ -2,8 +2,8 @@
 
 ROV build code:
 
-- `git clone https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023.git`
-- `cd cabrillo_rov_2023`
+- `git clone https://github.com/CabrilloRoboticsClub/seahawk.git`
+- `cd seahawk`
 - `git submodule init`
 - `git submodule update`
 - `sudo rosdep init`

--- a/doc/params.md
+++ b/doc/params.md
@@ -4,7 +4,7 @@
 ## Usage
 ### Client node
 *The client node is the node which makes a request to update another node's parameters*
-1. Import the `SetRemoteParams` class to any node on the deck with the following syntax. The `SetRemoteParams` class from [`set_remote_params.py`](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023/blob/main/src/seahawk/seahawk_deck/set_remote_params.py) provides functionality for nodes to modify each other's [ROS parameters](https://docs.ros.org/en/humble/Concepts/Basic/About-Parameters.html) using [services](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.html). The `SetRemoteParams` class streamlines setting another node's parameters to a user-friendly abstraction to reduce redundancy, creating cleaner code and increased ease-of-use.
+1. Import the `SetRemoteParams` class to any node on the deck with the following syntax. The `SetRemoteParams` class from [`set_remote_params.py`](https://github.com/CabrilloRoboticsClub/seahawk/blob/main/src/seahawk/seahawk_deck/set_remote_params.py) provides functionality for nodes to modify each other's [ROS parameters](https://docs.ros.org/en/humble/Concepts/Basic/About-Parameters.html) using [services](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Understanding-ROS2-Services/Understanding-ROS2-Services.html). The `SetRemoteParams` class streamlines setting another node's parameters to a user-friendly abstraction to reduce redundancy, creating cleaner code and increased ease-of-use.
 	```py
 	ffrom seahawk_deck.set_remote_params import SetRemoteParams
 	```
@@ -28,7 +28,7 @@
     from rclpy.parameter import Parameter
     from rcl_interfaces.msg import SetParametersResult
     ```
-2. Within the `__init__()` function declare a parameter. Below is an example from [`thrust.py`](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023/blob/main/src/seahawk/seahawk_deck/thrust.py), additional examples can be found [here](https://roboticsbackend.com/rclpy-params-tutorial-get-set-ros2-params-with-python/#Setup_code_and_declare_ROS2_params_with_rclpy).
+2. Within the `__init__()` function declare a parameter. Below is an example from [`thrust.py`](https://github.com/CabrilloRoboticsClub/seahawk/blob/main/src/seahawk/seahawk_deck/thrust.py), additional examples can be found [here](https://roboticsbackend.com/rclpy-params-tutorial-get-set-ros2-params-with-python/#Setup_code_and_declare_ROS2_params_with_rclpy).
     ```py
     # Parameter name is center_of_mass_offset
     # Its initial value is [0.0, 0.0, 0.0]
@@ -40,7 +40,7 @@
     # it can have any name deemed descriptive
     self.add_on_set_parameters_callback(self.update_center_of_mass)
     ```
-4. Write the function called when a parameter is updated. Add any logic deemed necessary. It is recommended to store the parameter in an attribute which is then accessed by the class if the value is used outside the callback. Below is an example from [`thrust.py`](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023/blob/main/src/seahawk/seahawk_deck/thrust.py).
+4. Write the function called when a parameter is updated. Add any logic deemed necessary. It is recommended to store the parameter in an attribute which is then accessed by the class if the value is used outside the callback. Below is an example from [`thrust.py`](https://github.com/CabrilloRoboticsClub/seahawk/blob/main/src/seahawk/seahawk_deck/thrust.py).
     ```py
     def update_center_of_mass(self, params: list[Parameter]) -> SetParametersResult:
         """

--- a/doc/rviz.md
+++ b/doc/rviz.md
@@ -68,7 +68,7 @@
 - Keep the parameters {`Ix`, `Iy`, `Iz`} as they are and click `export URDF` to proceed.
 
 ### 2 Import files to the project
-Most RViz related files are found in [`seahawk_description`](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023/tree/main/src/seahawk_description). This is where the files from SolidWorks will be added. Of these files, the majority can remain untouched when updating to a new model. The files which must be updated include `base_link.STL`, `seahawk_description.csv` and `seahawk_description.urdf`, the remaining can and should remain unmodified.
+Most RViz related files are found in [`seahawk_description`](https://github.com/CabrilloRoboticsClub/seahawk/tree/main/src/seahawk_description). This is where the files from SolidWorks will be added. Of these files, the majority can remain untouched when updating to a new model. The files which must be updated include `base_link.STL`, `seahawk_description.csv` and `seahawk_description.urdf`, the remaining can and should remain unmodified.
 
 ![seahawk_description directory](img/seahawk_description_directory.png)
 
@@ -86,7 +86,7 @@ Most RViz related files are found in [`seahawk_description`](https://github.com/
 - Ensure the files retain the names, `seahawk_description.csv` and `seahawk_description.urdf`
 
 ### 3 Update `rviz_markers.py` motor config
-[`rviz_markers.py`](https://github.com/CabrilloRoboticsClub/cabrillo_rov_2023/blob/main/src/seahawk/seahawk_deck/rviz_markers.py) is responsible for creating [Markers](http://wiki.ros.org/rviz/DisplayTypes/Marker) which display the thrust vectors in RViz. For a new model, the `MOTORS` list must be updated with updated motor positions and rotation.
+[`rviz_markers.py`](https://github.com/CabrilloRoboticsClub/seahawk/blob/main/src/seahawk/seahawk_deck/rviz_markers.py) is responsible for creating [Markers](http://wiki.ros.org/rviz/DisplayTypes/Marker) which display the thrust vectors in RViz. For a new model, the `MOTORS` list must be updated with updated motor positions and rotation.
 ```py
 # Position and angle constants for top motors (0-3)
 X_TOP = 0.2

--- a/doc/setup_procedure.md
+++ b/doc/setup_procedure.md
@@ -54,7 +54,7 @@ Person 1 and person 2 work in parallel
 1. in the first window launch the deck
 
 ```console
-source ~/cabrillo_rov_2023/install/setup.bash && ros2 launch seahawk_deck deck.launch.py
+source ~/seahawk/install/setup.bash && ros2 launch seahawk_deck deck.launch.py
 ```
 
 1. In the second window ssh into the rov
@@ -66,13 +66,13 @@ ssh ubuntu@SeaHawk-ROV.lan
 1. In the second window launch the ROV
 
 ```console
-source ~/cabrillo_rov_2023/install/setup.bash && ros2 launch seahawk_rov rov.launch.py
+source ~/seahawk/install/setup.bash && ros2 launch seahawk_rov rov.launch.py
 ```
 
 1. In the third window open rqt
 
 ```console
-source ~/cabrillo_rov_2023/install/setup.bash && rqt
+source ~/seahawk/install/setup.bash && rqt
 ```
 
 ## YOU ARE READY TO DRIVE THE ROV


### PR DESCRIPTION
The current name of the repo is outdated and needs to be updated. The new name "seahawk" allows us to continue iterating on this software without having to change the name again in the future (unless we move away from the name seahawk). This PR updates any broken links in the repo due to the name change. Addresses issue #205 